### PR TITLE
Add async (with sync opt-in) & Remove configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,6 @@
     "rollup": "^0.49.3",
     "tape": "^4.8.0"
   },
-  "dependencies": {
-    "execa": "^0.8.0",
-    "tempy": "^0.2.0",
-    "util-promisify": "^2.1.0"
-  },
   "keywords": [
     "rollup",
     "webassembly",

--- a/readme.md
+++ b/readme.md
@@ -3,13 +3,9 @@
 
 > Import WebAssembly code with Rollup
 
-Use this [Rollup plugin](https://rollupjs.org) to import source code which compiles to WebAssembly (such as C, C++, Wat, Rust), or just import standalone `.wasm` binaries.  There are a few configs to quick-start languages:
+Use this [Rollup](https://github.com/rollup/rollup) plugin to import WebAssembly modules.
 
- - `wasm.emscripten` for C and C++ using [Emscripten](https://github.com/kripken/emscripten)
- - `wasm.wabt` for WAT using [WABT](https://github.com/webassembly/wabt)
- - Others? [Submit an issue](https://github.com/jamen/rollup-plugin-wasm/issues/new)
-
-You can also create your own configs. See [Configs](#configurations) and [`src/index.js`](https://github.com/jamen/rollup-plugin-wasm/blob/master/src/index.js) for more details.
+By default, WebAssembly modules are imported as a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), But you can use the `sync` flag to specify otherwise (See ["Sync Modules"](#sync_modules)).
 
 ## Install
 
@@ -21,87 +17,66 @@ npm i -D rollup-plugin-wasm
 
 ## Usage
 
-Load the plugin in your `rollup.config.js`:
+First, load the plugin into your rollup config
 
 ```js
+import { rollup } from 'rollup'
 import wasm from 'rollup-plugin-wasm'
 
 export default {
-  plugins: [ wasm() ]
+  input: 'web/index.js',
+  plugins: [
+    wasm()
+  ]
 }
 ```
 
-You can use the configs like so:
+Then import & instantiate WebAssembly modules:
 
 ```js
-import wasm, { emscripten } from 'rollup-plugin-wasm'
+import sample from './sample.wasm'
+
+sample
+.then(module => {
+  return WebAssembly.instantiate(module, {
+    // imports
+  })
+})
+.then(instance => {
+  console.log(instance.exports.main())
+})
+```
+
+## Sync Modules
+
+You can compile modules synchronously by specifying it in the config
+
+```js
+import { rollup } from 'rollup'
+import wasm from 'rollup-plugin-wasm'
 
 export default {
-  plugins: [ wasm(emscripten) ]
+  input: 'web/index.js',
+  plugins: [
+    wasm({
+      sync: [
+        'web/sample.wasm',
+        'web/foobar.wasm',
+        'web/hello.wasm'
+      ]
+    })
+  ]
 }
 ```
 
-### `wasm(config)`
-
-The base of the plugin lets you require plain `.wasm` files.  You can use your own commands to compile standalone binaries, and then import them from JavaScript.
+Which import the modules directly instead of being wrapped in a promise
 
 ```js
-import createFoo from './foo.wasm'
+import sample from './sample.wasm'
 
-var foo = createFoo(imports)
+const instance = new WebAssembly.Instance(sample, {
+  // imports
+})
 
-foo.main()
+console.log(instance.exports.main())
 ```
-
-But, you may also provide a config for importing source files.  More info below
-
-### `wasm.emscripten`
-
-For importing C and C++ an `emscripten` config is provided. It uses [Emscripten](https://github.com/kripken/emscripten)'s `emcc` command for the compilation.
-
-```js
-import sample from './sample.cc'
-
-sample._main()
-```
-
-### `wasm.wabt`
-
-For importing `.wat` the `wabt` config is provided, which uses [WABT](https://github.com/WebAssembly/WABT)'s `wat2wasm` command for the compilation.
-
-
-```js
-import createFoo from './foo.wat'
-
-const foo = createFoo()
-
-foo.main()
-```
-
-### Configs
-
-The config objects are expressed as:
-
-```js
-{
-  compile(code, id): Promise<wasm>,
-  load(wasm): any
-}
-```
-
-The `compile` function is responsible for turning a source file into WebAssembly.  For example, spawning the command of a compiler and getting the results.
-
-The `load` function gets embed in the bundle, and is responsible for returning the exports for an import.  By default this is simply:
-
-```js
-load(wasm) -> init(imports) -> exports
-```
-
-Which looks like this from the source:
-
-```js
-import createFoo from './source.ex'
-
-var exports = createFoo(imports)
-```
-

--- a/readme.md
+++ b/readme.md
@@ -3,9 +3,7 @@
 
 > Import WebAssembly code with Rollup
 
-Use this [Rollup](https://github.com/rollup/rollup) plugin to import WebAssembly modules.
-
-By default, WebAssembly modules are imported as a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), But you can use the `sync` flag to specify otherwise (See ["Sync Modules"](#sync_modules)).
+Use this [Rollup](https://github.com/rollup/rollup) plugin to import WebAssembly modules.  They are imported as a [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module) wrapped in a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), but you can use the `sync` option for small modules if you wish (see ["Sync Modules"](#sync_modules)).
 
 ## Install
 
@@ -13,11 +11,9 @@ By default, WebAssembly modules are imported as a [Promise](https://developer.mo
 npm i -D rollup-plugin-wasm
 ```
 
-**Note:** For quick-start configs to work you must install their parent projects (Emscripten, WABT, etc.)
-
 ## Usage
 
-First, load the plugin into your rollup config
+First, load the plugin into your rollup config.
 
 ```js
 import { rollup } from 'rollup'
@@ -31,7 +27,7 @@ export default {
 }
 ```
 
-Then import & instantiate WebAssembly modules:
+Then, you can import & instantiate WebAssembly modules.
 
 ```js
 import sample from './sample.wasm'
@@ -47,9 +43,11 @@ sample
 })
 ```
 
+The imports are simply [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module) objects which get instantiated by you.
+
 ## Sync Modules
 
-You can compile modules synchronously by specifying it in the config
+Small modules (< 4KB) can be compiled synchronously by specifying them in the config.
 
 ```js
 import { rollup } from 'rollup'
@@ -69,7 +67,7 @@ export default {
 }
 ```
 
-Which import the modules directly instead of being wrapped in a promise
+This imports the `WebAssembly.Module` directly instead of being wrapped in a promise.
 
 ```js
 import sample from './sample.wasm'

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 
 > Import WebAssembly code with Rollup
 
-Use this [Rollup](https://github.com/rollup/rollup) plugin to import WebAssembly modules.  They are imported as a [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module) wrapped in a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), but you can use the `sync` option for small modules if you wish (see ["Sync Modules"](#sync_modules)).
+Use this [Rollup](https://github.com/rollup/rollup) plugin to import WebAssembly modules.  They are imported as a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) from being compiled asynchronously, but you can use the `sync` option for small modules if you wish (see [Sync Modules](#sync_modules)).
 
 ## Install
 
@@ -45,7 +45,7 @@ sample
 
 The imports are simply [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module) objects which get instantiated by you.
 
-## Sync Modules
+### Sync Modules
 
 Small modules (< 4KB) can be compiled synchronously by specifying them in the config.
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,11 @@
 
+const dependencies = Object.keys(require('./package.json').dependencies || {})
+
 export default [
   {
     input: 'src/index.js',
     output: { file: 'dist/rollup-plugin-wasm.js', format: 'cjs' },
-    external: ['fs', 'child_process'].concat(Object.keys(require('./package.json').dependencies)),
+    external: ['path'].concat(dependencies),
     exports: 'named'
   },
   {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export default function wasm (options = {}) {
   return {
     name: 'wasm',
     
-    banner:  `\
+    banner:  `
       function _wasmLoadModule (sync, src) {
         var len = src.length
         var trailing = src[len-2] == '=' ? 2 : src[len-1] == '=' ? 1 : 0 

--- a/src/index.js
+++ b/src/index.js
@@ -1,41 +1,16 @@
 
-import fs from 'fs'
-import spawn from 'execa'
-import { file as temp } from 'tempy'
-import promisify from 'util-promisify'
-
-const read = promisify(fs.readFile)
-const unlink = promisify(fs.unlink)
-
-function compileWasm (code) {
-  if (code) {
-    code = Buffer.from(code, 'binary').toString('base64')
-    return `export default _loadWasmModule('${code}')`
-  }  
-}
+import path from 'path'
 
 export default function wasm (options = {}) {
   options = Object.assign({}, options)
 
-  // Default to simple universal load
-  if (!options.load) options.load = wabt.load
-
-  // Turn it into a string for embedding in client code
-  options.load = options.load.toString()
-
-  // Fix quirk where "foo () { }" method syntax breaks the expression
-  if (
-    /^([^\ ]+)(\s*)\(.*\)(\s*)\{/.test(options.load) &&
-    !/^function(\s*)\(/.test(options.load)
-  ) {
-    options.load = 'function ' + options.load
-  }
+  const syncFiles = (options.sync || []).map(x => path.resolve(x))
 
   return {
     name: 'wasm',
     
     banner:  `\
-      function _loadWasmModule (src) {
+      function _wasmLoadModule (sync, src) {
         var len = src.length
         var trailing = src[len-2] == '=' ? 2 : src[len-1] == '=' ? 1 : 0 
         var buf = new Uint8Array((len * 3/4) - trailing)
@@ -52,64 +27,17 @@ export default function wasm (options = {}) {
           buf[b++] = ((third & 3) << 6) | (table[src.charCodeAt(i+3)] & 63)
         }
 
-        return (${options.load})(buf)
+        return sync ? new WebAssembly.Module(buf) : WebAssembly.compile(buf)
       }
     `.trim(),
     
     transform (code, id) {      
-      if (/\.wasm$/.test(id)) {
-        // Compile wasm -> js
-        return compileWasm(code)
-      } else if (options.compile) {
-        // Compile source code -> wasm -> js
-        return Promise.resolve(options.compile(code, id)).then(compileWasm)
+      if (code && /\.wasm$/.test(id)) {
+        const src = Buffer.from(code, 'binary').toString('base64')
+        const sync = syncFiles.indexOf(id) === -1
+        return `export default _wasmLoadModule(${+sync}, '${src}')`
       }
     }
   }
 }
-
-export const emscripten = {
-  compile (code, id) {
-    if (/.(c|cc|cpp)$/.test(id)) {
-      const temppath = temp({ extension: 'wasm' })
-      return spawn('emcc', [id, '-Os', '-s', 'BINARYEN=1', '-s', 'SIDE_MODULE=1', '-o', temppath])
-        .then(results => read(temppath, 'binary'))
-        .then(contents => unlink(temppath).then(() => contents))
-    }    
-  },
-  // From https://gist.github.com/kripken/59c67556dc03bb6d57052fedef1e61ab
-  load (buf) {
-    var module = new WebAssembly.Module(buf)
-    var instance = new WebAssembly.Instance(module, {
-      env: {
-        memoryBase: 0,
-        tableBase: 0,
-        memory: new WebAssembly.Memory({ initial: 256 }),
-        table: new WebAssembly.Table({ initial: 0, element: 'anyfunc' }),
-        _puts: console.log
-      }
-    })
-    instance.exports.__post_instantiate()
-    return instance.exports 
-  }
-}
-
-export const wabt = {
-  compile (code, id) {
-    if (/.wa(t|st)$/.test(id)) {
-      const temppath = temp({ extension: 'wasm' })
-      return spawn('wat2wasm', [id, '-o', temppath])
-        .then(results => read(temppath, 'binary'))
-        .then(contents => unlink(temppath).then(() => contents))
-    }
-  },
-  load (buf) {
-    return imports => {
-        var module = WebAssembly.Module(buf)
-        var instance = WebAssembly.Instance(module, imports)
-        return instance.exports
-     }
-  }
-}
-
 

--- a/test/fixture/async.js
+++ b/test/fixture/async.js
@@ -1,0 +1,13 @@
+
+import sample from './sample.wasm'
+
+sample
+.then(module => {
+  return WebAssembly.instantiate(module, {
+    // ...
+  })
+})
+.then(instance => {
+  t.is(instance.exports.main(), 3, 'wasm loaded')
+})
+

--- a/test/fixture/async.js
+++ b/test/fixture/async.js
@@ -4,7 +4,7 @@ import sample from './sample.wasm'
 sample
 .then(module => {
   return WebAssembly.instantiate(module, {
-    // ...
+    env: {}
   })
 })
 .then(instance => {

--- a/test/fixture/cc.js
+++ b/test/fixture/cc.js
@@ -1,5 +1,0 @@
-
-import sample from './sample.cc'
-
-console.log(sample)
-

--- a/test/fixture/imports.js
+++ b/test/fixture/imports.js
@@ -1,0 +1,11 @@
+
+import sample from './imports.wasm'
+
+var instance = new WebAssembly.Instance(sample, {
+  env: {
+    foobar: x => t.is(x, 10, 'got callback')
+  }
+})
+
+instance.exports.main()
+

--- a/test/fixture/imports.wat
+++ b/test/fixture/imports.wat
@@ -1,0 +1,7 @@
+(module
+  (func $foobar (import "env" "foobar") (param i32))
+  (func (export "main")
+    (call $foobar (i32.const 10))      
+  )
+)
+

--- a/test/fixture/sample.cc
+++ b/test/fixture/sample.cc
@@ -1,7 +1,0 @@
-
-#include <stdio.h>
-
-int main () {
-  return 0;
-}
-

--- a/test/fixture/sample.wat
+++ b/test/fixture/sample.wat
@@ -1,5 +1,7 @@
 (module
-  (func (export "main") (result i32)
-    (i32.add (i32.const 1) (i32.const 2))
+  (func (export "main")
+    (result i32)
+    (i32.const 3)
   )  
 )
+

--- a/test/fixture/sync.js
+++ b/test/fixture/sync.js
@@ -2,7 +2,7 @@
 import sample from './sample.wasm'
 
 var instance = new WebAssembly.Instance(sample, {
-  // ...
+  env: {}
 })
 
 t.is(instance.exports.main(), 3, 'wasm loaded')

--- a/test/fixture/sync.js
+++ b/test/fixture/sync.js
@@ -1,0 +1,9 @@
+
+import sample from './sample.wasm'
+
+var instance = new WebAssembly.Instance(sample, {
+  // ...
+})
+
+t.is(instance.exports.main(), 3, 'wasm loaded')
+

--- a/test/fixture/wasm.js
+++ b/test/fixture/wasm.js
@@ -1,5 +1,0 @@
-
-import sample from './sample.wasm'
-
-console.log(sample().main())
-

--- a/test/fixture/wat.js
+++ b/test/fixture/wat.js
@@ -1,5 +1,0 @@
-
-import sample from './sample.wat'
-
-console.log(sample().main())
-

--- a/test/index.js
+++ b/test/index.js
@@ -3,63 +3,39 @@ import { rollup } from 'rollup'
 import wasm, { wabt, emscripten } from '../src/index.js'
 import test from 'tape'
 
-test('Bundling .wasm code', t => {
+function testBundle (t, bundle) {
+  bundle.generate({ format: 'cjs' })
+  .then(({ code }) => {
+    new Function('t', code)(t)
+  })
+}
+
+test('async wasm code', t => {
   t.plan(1)
 
   rollup({
-    input: 'test/fixture/wasm.js',
+    input: 'test/fixture/sync.js',
     plugins: [
       wasm()
     ],
   })
-  .then(bundle => bundle.generate({ format: 'iife' }), t.error)
-  .then(result => {
-    t.true(result, 'got wasm bundle')
-    // demo:
-    // console.log(result.code)
-  })
+  .then(bundle => testBundle(t, bundle))
 })
 
-test('Bundling .wat code', t => {
-  t.plan(2)
 
-  rollup({
-    input: 'test/fixture/wat.js',
-    plugins: [
-      wasm(wabt)
-    ],
-  })
-  .then(bundle => bundle.generate({ format: 'iife' }), t.error)
-  .then(result => {
-    var code = result.code
-    var funcdef = code.indexOf('function _loadWasmModule')
-    var wasmimport = code.indexOf('_loadWasmModule(\'AG')
-    
-    t.not(-1, funcdef, 'found wasm load definition')
-    t.not(-1, wasmimport, 'found wasm load call')
-
-    // demo:
-    // console.log(code)
-  }, t.error)
-})
-
-test('Bundling .cc code', t => {
+test('async wasm code', t => {
   t.plan(1)
 
   rollup({
-    input: 'test/fixture/cc.js',
+    input: 'test/fixture/async.js',
     plugins: [
-      wasm(emscripten)
+      wasm({
+        sync: [
+          'test/fixture/sample.wasm'
+        ]
+      })
     ],
   })
-  .then(bundle => bundle.generate({ format: 'iife' }), t.error)
-  .then(result => {
-    var code = result.code
-    var funcdef = code.indexOf('anyfunc')
-    
-    t.not(-1, funcdef, 'found custom wasm load')
-
-    // demo:
-    // console.log(code)
-  }, t.error)
+  .then(bundle => testBundle(t, bundle))
 })
+

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,7 @@ function testBundle (t, bundle) {
   })
 }
 
-test('async wasm code', t => {
+test('async compiling', t => {
   t.plan(1)
 
   rollup({
@@ -23,7 +23,7 @@ test('async wasm code', t => {
 })
 
 
-test('async wasm code', t => {
+test('sync compiling', t => {
   t.plan(1)
 
   rollup({
@@ -37,5 +37,22 @@ test('async wasm code', t => {
     ],
   })
   .then(bundle => testBundle(t, bundle))
+})
+
+test('imports', t => {
+  t.plan(1)
+
+  rollup({
+    input: 'test/fixture/imports.js',
+    plugins: [
+      wasm({
+        sync: [
+          'test/fixture/sample.wasm'
+        ]
+      })
+    ],
+  })
+  .then(bundle => testBundle(t, bundle))
+
 })
 


### PR DESCRIPTION
This PR adds async compiling (opt-in for sync) and removes the expermental "configs" to simplify the package.

I've also change what imports.  It is no longer `init(imports)`, it is just the plain `WebAssembly.Module` wrapped in a promise.  You pass it into `WebAssembly.instantiate` yourself.

\cc @ColinEberhardt